### PR TITLE
no access for this.parameters at isSignatureValid

### DIFF
--- a/lib/paymentwall/pingback.js
+++ b/lib/paymentwall/pingback.js
@@ -25,7 +25,7 @@ util._extend(Pingback.prototype, {
 
 		if (this.isParametersValid()) {
 			if (this.isIpAddressValid() || skipIpWhitelistCheck) {
-				if (this.isSignatureValid()) {
+				if (this.isSignatureValid.bind(this)) {
 					validated = true;
 				} else {
 					this.appendToErrors('Wrong signature');


### PR DESCRIPTION
force isSignatureValid useing this. of Pingback Object to get access for parameters otherwise its empty and therefore validation fails.