### PR TITLE
instanceof -> typeof in Pingback.js

### DIFF
--- a/lib/Pingback.js
+++ b/lib/Pingback.js
@@ -14,7 +14,7 @@ function Pingback(parameters, ipAddress, pingbackForBrick) {
 	this.errors = [];
 	if(typeof(parameters) === "string"){
 		parameters = querystring.parse(parameters);
-	} else if(parameters instanceof Object){
+	} else if(typeof(parameters) === "object"){
 
 	} else {
 		console.log("Error: Please pass Object as the queryData in Paymentwall.Pingback(queryData, ip)");


### PR DESCRIPTION
`instanceof` [uses check via prototype](https://learn.javascript.ru/instanceof) (link in Russian; so sometimes `instanceof` fails). `typeof` is more safe way to check type.